### PR TITLE
优化：实现流水线Load-Use冒险检测与暂停逻辑

### DIFF
--- a/myCPU_debug/ID.v
+++ b/myCPU_debug/ID.v
@@ -120,6 +120,12 @@ wire [31:0] rf_rdata2_forward =
     (ms_rf_we && (ms_rf_waddr != 0) && (ms_rf_waddr == rf_raddr2)) ? ms_rf_wdata :
     rf_rdata2;
 
+// Load-Use冒险检测
+wire load_use_hazard = 
+    es_rf_we && (es_rf_waddr != 0) && data_sram_en && (
+        (rf_raddr1 == es_rf_waddr) || (rf_raddr2 == es_rf_waddr)
+    );
+
 // 分支判断
 wire rj_eq_rd = (rf_rdata1_forward == rf_rdata2_forward);
     
@@ -170,7 +176,7 @@ always @(posedge clk) begin
 end
 // 流水线控制
 assign ds_pc = pc;
-assign ds_ready_go = !stall;
+assign ds_ready_go = !stall && !load_use_hazard;
 assign ds_allow_in = !ds_valid || es_allow_in && ds_ready_go;
 
 always @(posedge clk) begin


### PR DESCRIPTION
本次提交内容：
1. 在ID阶段（ID.v）实现了对Load-Use型数据冒险的检测逻辑。具体做法为：当EXE阶段为load指令，且ID阶段指令需要用到该load结果时，自动检测到冒险情况。
2. 新增load_use_hazard信号，若发生Load-Use冒险，则暂停流水线推进，防止因数据尚未写回而被错误读取，确保数据正确性。
3. 修改ds_ready_go信号，将load_use_hazard纳入流水线推进条件，只有在无冒险时流水线才继续运行。
4. 该优化可有效避免因load-use冒险导致的错误结果，提升CPU流水线的健壮性和符合龙芯32位精简版架构规范的实现。